### PR TITLE
Fix in handleTouchEnd for getting a valid target

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,16 @@ function handleTouchEnd (event) {
 
     const x = event.changedTouches[0].clientX;
     const y = event.changedTouches[0].clientY;
+    const dragPreview = touchDndCustomEvents.store.dragPreviewElement;
+    const previewContainer = updateDragPreview(dragPreview, x, y);
+
+    // hide dragPreview so we can get the element underneath
+    previewContainer.hidden = true;
+
     const target = document.elementFromPoint(x, y);
+
+    // show dragPreview again
+    previewContainer.hidden = false;
 
     const dataTransfer = touchDndCustomEvents.dataTransfer;
 


### PR DESCRIPTION
Preview container wasn't hidden before getting target by document.elementFromPoint