### PR TITLE
Fix for simulateEvent method and dragend event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ function handleTouchEnd (event) {
     simulateEvent('touchdrop', event, dataTransfer, target);
 
     touchDndCustomEvents.store.mode = 'protected';
-    simulateEvent('touchdragend', event, dataTransfer, target);
+    simulateEvent('touchdragend', event, dataTransfer, touchDndCustomEvents.draggedItem);
 
     touchDndCustomEvents.store = null;
     touchDndCustomEvents.dataTransfer = null;

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,16 @@ function handleTouchEnd (event) {
 
     const x = event.changedTouches[0].clientX;
     const y = event.changedTouches[0].clientY;
+    const dragPreview = touchDndCustomEvents.store.dragPreviewElement;
+    const previewContainer = updateDragPreview(dragPreview, x, y);
+
+    // hide dragPreview so we can get the element underneath
+    previewContainer.hidden = true;
+
     const target = document.elementFromPoint(x, y);
+
+    // show dragPreview again
+    previewContainer.hidden = false;
 
     const dataTransfer = touchDndCustomEvents.dataTransfer;
 

--- a/src/simulateEvent.js
+++ b/src/simulateEvent.js
@@ -8,8 +8,8 @@ const allowedEvents = {
   'touchdrop': null
 };
 
-function ensureParamsCorrect (type, touchEvent, dataTransfer, target) {
-  if (!type || !touchEvent || !dataTransfer || !target) {
+function ensureParamsCorrect (type, touchEvent, dataTransfer) {
+  if (!type || !touchEvent || !dataTransfer) {
     throw new Error("simulateEvent: arguments can't be undefined");
   }
 
@@ -19,7 +19,10 @@ function ensureParamsCorrect (type, touchEvent, dataTransfer, target) {
 }
 
 export default function simulateEvent(type, touchEvent, dataTransfer, target) {
-  ensureParamsCorrect(type, touchEvent, dataTransfer, target);
+  if (!target) {
+    return;
+  }
+  ensureParamsCorrect(type, touchEvent, dataTransfer);
 
   const touchDetails = touchEvent.changedTouches[0];
   const event = new Event(type, {'bubbles': true});


### PR DESCRIPTION
Dragend was fired at target, not source element.
simulateEvent was throwing error when finger was moved out of browser window while dragging.
