### PR TITLE
Draggable attribute requires a value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const touchDndCustomEvents = {
 
 function handleTouchStart (event) {
   const target = event.target;
-  if (target.hasAttribute("draggable")) {
+  if (target.getAttribute("draggable") === 'true') {
     event.preventDefault();
 
     const x = event.changedTouches[0].clientX;


### PR DESCRIPTION
It requires a true/false value. Shorthand like a <div draggable> is not allowed.